### PR TITLE
Add `Main.hs` to fix the build failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+.stack-work/

--- a/Main.hs
+++ b/Main.hs
@@ -1,0 +1,13 @@
+module Main where
+
+import System.Environment (getArgs)
+import System.Exit (die)
+
+import HSFmt (prettyPrintFile)
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    []    -> die "Please specify a filename."
+    (f:_) -> prettyPrintFile f >>= putStrLn

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 A Haskell code formatter using prettyprinter and the GHC API
 
 This project is not complete. Don't tell me you don't like how it looks, because neither do I. We'll get there. However, if you want to send a pull request that changes formatting, by all means go ahead! Just make sure the tests all pass :)
+
+
+## Usage
+
+Right now, `hs-fmt` just formats a single file, and prints out the result to `STDOUT`.
+
+
+    $ stack build
+    $ stack exec -- hs-fmt FILENAME


### PR DESCRIPTION
My intent was just to fix the build failure because of the missing `Main.hs`. The `main` function is really stupid. It grabs the first command line argument (assuming that it's a filepath), formats it, and prints out the result to `STDOUT`. Eventually, we might want to add an argument parser or something similar. But I've tried not to change too much for my first PR.

I imagine that you might have already have a `Main.hs` on your machine, but just forgot to check it in ? In that case, we could totally ignore this one :-)